### PR TITLE
Direct actions to master repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MAINTAINER [OIVAS7572](https://github.com/OIVAS7572)
 
-[![Python](https://github.com/TheYoBots/lichess-bot-1/actions/workflows/python-app.yml/badge.svg)](https://github.com/TheYoBots/lichess-bot-1/actions/workflows/python-app.yml)
-[![Docker](https://github.com/TheYoBots/lichess-bot-1/actions/workflows/docker-image.yml/badge.svg)](https://github.com/TheYoBots/lichess-bot-1/actions/workflows/docker-image.yml)
+[![Python](https://github.com/OIVAS7572/lichess-bot/actions/workflows/python-app.yml/badge.svg)](https://github.com/OIVAS7572/lichess-bot/actions/workflows/python-app.yml)
+[![Docker](https://github.com/OIVAS7572/lichess-bot/actions/workflows/docker-image.yml/badge.svg)](https://github.com/OIVAS7572/lichess-bot/actions/workflows/docker-image.yml)
 
 # lichess-bot
 


### PR DESCRIPTION
The actions created were directed to the actions taking place in my repo (https://github.com/TheYoBots/lichess-bot-1/actions) instead of your repo (https://github.com/OIVAS7572/lichess-bot/actions). I’ve updated this to direct to the actions in your repo instead of those in mine.